### PR TITLE
[Feat] KAN-17 Product entity 구현

### DIFF
--- a/schoolmate/src/main/java/com/spring/schoolmate/entity/Product.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/entity/Product.java
@@ -1,0 +1,41 @@
+package com.spring.schoolmate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.Date;
+
+@Builder
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "products")
+public class Product {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "product_id")
+  private Integer productId; // 상품 아이디
+
+  @Column(name = "product_category", length = 100, nullable = false)
+  private String productCategory; // 상품 카테고리
+
+  @Column(name = "product_name", length = 100, nullable = false)
+  private String productName; // 상품명
+
+  @Column(name = "product_points", nullable = false)
+  private Integer productPoints; // 상품 포인트
+
+  @Column(name = "expiration_date", nullable = false)
+  private Date expirationDate; // 상품 유효기간
+
+  @Column(name = "stock", nullable = false)
+  private Integer stock; // 재고 수량
+
+  @Column(name = "total_quantity", nullable = false)
+  private Integer totalQuantity; // 총 수량
+
+  @Column(name = "registration_date", nullable = false)
+  private Date registrationDate; // 상품 등록 일자
+}

--- a/schoolmate/src/main/java/com/spring/schoolmate/entity/ProductExchange.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/entity/ProductExchange.java
@@ -1,0 +1,37 @@
+package com.spring.schoolmate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.Date;
+
+@Builder
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "product_exchange")
+public class ProductExchange {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "productexchange_id")
+  private Integer productExchangeId; // 교환 상품 아이디
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "student_id", nullable = false)
+  private Student student; // 학생 엔터티
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id", nullable = false)
+  private Product product; // 상품 엔터티
+
+  @Column(name = "exchange_date", nullable = false)
+  private Date exchangeDate; // 상품 교환 일자
+
+  @Column(name = "usage_date", nullable = true)
+  private Date usageDate; // 상품 사용 일자
+
+  @Column(name = "exchangecard_status", length = 20, nullable = true)
+  private String exchangeCardStatus; // 교환 상품 사용 상태
+}


### PR DESCRIPTION
jira : KAN-17

# Todo
- [x] Product Entity 구현
- [x] ProductExchange Entity 구현

# etc
- ProductExchange Entity 구현
  - `productexchange_id`를 기본 키로 설정했습니다.
  - `student_id`와 `product_id`를 외래 키로 참조하며, **`FetchType.LAZY`**를 사용하여 Student와 Product 엔티티를 지연 로딩하도록 구현했습니다.
  - `exchange_date`와 `usage_date`, `exchangecard_status` 필드를 컬럼에 맞게 매핑했습니다.