### PR TITLE
[Feat] KAN-19 ProductHistory Entity 구현

### DIFF
--- a/schoolmate/src/main/java/com/spring/schoolmate/entity/PointHistory.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/entity/PointHistory.java
@@ -1,0 +1,45 @@
+package com.spring.schoolmate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.sql.Timestamp;
+
+@Builder
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "point_history")
+public class PointHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "ph_id")
+  private Long phId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "student_id", nullable = false)
+  private Student student;
+
+  @Column(name = "transaction_type", length = 50, nullable = false)
+  private String transactionType;
+
+  @Column(name = "amount", nullable = false)
+  private Integer amount;
+
+  @Column(name = "balance_after", nullable = false)
+  private Integer balanceAfter;
+
+  @Column(name = "reference_type", length = 50, nullable = true)
+  private String referenceType;
+
+  @Column(name = "reference_id", nullable = true)
+  private Long referenceId;
+
+  @Column(name = "created_at", nullable = false)
+  private Timestamp createdAt;
+
+  @Column(name = "expires_at", nullable = true)
+  private Timestamp expiresAt;
+}


### PR DESCRIPTION
jira : KAN-19

# Todo
- [x] PointHistroy Entity 구현

# etc
- PointHistory Entity 구현
  - `ph_id`를 기본 키로 설정하고, `student`와 **다대일(N:1) 관계**를 매핑했습니다.
  - `transaction_type`과 `amount` 같은 필드들을 컬럼에 맞춰 구현했습니다.
  - `created_at`과 `expires_at` 필드는 `Timestamp` 타입으로 매핑했습니다.