### PR TITLE
[Fix] KAN-56 소셜 로그인 redirect 오류 수정

### DIFF
--- a/schoolmate/src/main/java/com/spring/schoolmate/exception/UserNotRegisteredException.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/exception/UserNotRegisteredException.java
@@ -1,0 +1,26 @@
+package com.spring.schoolmate.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.Map;
+
+@Getter
+public class UserNotRegisteredException extends AuthenticationException {
+
+  private final Map<String, Object> attributes;
+  private final String provider;
+
+  public UserNotRegisteredException(String msg, Map<String, Object> attributes, String provider) {
+    super(msg);
+    this.attributes = attributes;
+    this.provider = provider;
+  }
+
+  // 기존 생성자 유지
+  public UserNotRegisteredException(String msg, Throwable cause, Map<String, Object> attributes, String provider) {
+    super(msg, cause);
+    this.attributes = attributes;
+    this.provider = provider;
+  }
+}

--- a/schoolmate/src/main/java/com/spring/schoolmate/jwt/JWTUtil.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/jwt/JWTUtil.java
@@ -2,7 +2,7 @@ package com.spring.schoolmate.jwt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spring.schoolmate.entity.Admin; // 🚨 [추가] Admin 엔티티 임포트
+import com.spring.schoolmate.entity.Admin;
 import com.spring.schoolmate.entity.Student;
 import com.spring.schoolmate.security.OAuth2CustomUser;
 import io.jsonwebtoken.Jwts;
@@ -14,6 +14,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 // JWT 정보 검증 및 생성
@@ -31,12 +32,9 @@ public class JWTUtil {
         this.expirationTime = expirationTime;
     }
 
-    // ======================== 검증 메서드 확장 ========================
-
-    // 🚨 [수정] getStudentId 대신, 'ID'를 추출하는 공통 메서드 추가 (Student/Admin 모두 처리)
     public Long getId(String token) {
         String role = getRole(token);
-        String idClaimName = "STUDENT".equals(role) ? "studentId" : "adminId"; // claim 이름 분리 (호환성 유지)
+        String idClaimName = "STUDENT".equals(role) ? "studentId" : "adminId";
 
         log.info("getId(String token) :: call");
         Long rId = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(idClaimName, Long.class);
@@ -44,12 +42,6 @@ public class JWTUtil {
         return rId;
     }
 
-    // 🚨 [삭제] getStudentId 삭제 (getId로 통합)
-    /*
-    public Long getStudentId(String token) { ... }
-    */
-
-    // 검증 Email (변경 없음)
     public String getEmail(String token) {
         log.info("getEmail(String token) :: call");
         String rEmail = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
@@ -57,10 +49,8 @@ public class JWTUtil {
         return rEmail;
     }
 
-    // 🚨 [수정] getStudentName 대신, 'Name'을 추출하는 공통 메서드 추가
     public String getName(String token) {
         log.info("getName(String token)  call");
-        // JWT 생성 시 Student는 studentName, Admin은 name을 사용한다고 가정하고 분기 처리
         String rName = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("studentName", String.class);
         if (rName == null) {
             rName = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
@@ -69,13 +59,6 @@ public class JWTUtil {
         return rName;
     }
 
-    // 🚨 [삭제] getStudentName 삭제 (getName으로 통합)
-    /*
-    public String getStudentName(String token) { ... }
-    */
-
-
-    // 검증 Role (변경 없음)
     public String getRole(String token) {
         log.info("getRole(String token) :: call");
         String rRole = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
@@ -83,7 +66,6 @@ public class JWTUtil {
         return rRole;
     }
 
-    // 검증 Expired (변경 없음)
     public Boolean isExpired(String token) {
         log.info("isExpired(String token) :: call");
         try {
@@ -96,10 +78,6 @@ public class JWTUtil {
         }
     }
 
-
-    // ======================== 생성 메서드 확장 ========================
-
-    // Student용 JWT 생성 (변경 없음, claim key는 studentId, studentName 유지)
     public String createJwt(Student student) {
         log.info("createJwt(Student) call");
         return Jwts.builder()
@@ -113,13 +91,12 @@ public class JWTUtil {
           .compact();
     }
 
-    // 🚨 [추가] Admin용 JWT 생성
     public String createJwt(Admin admin) {
         log.info("createJwt(Admin) call");
         return Jwts.builder()
-          .claim("adminId", admin.getAdminId()) // 🚨 claim key를 adminId로 설정
+          .claim("adminId", admin.getAdminId())
           .claim("email", admin.getEmail())
-          .claim("role", admin.getRole().toString()) // RoleType이 아닌 Role Enum 자체를 쓴다고 가정
+          .claim("role", admin.getRole().toString())
           .issuedAt(new Date(System.currentTimeMillis()))
           .expiration(new Date(System.currentTimeMillis() + expirationTime))
           .signWith(secretKey)
@@ -127,23 +104,47 @@ public class JWTUtil {
     }
 
 
-    // 신규 소셜 회원을 위한 '임시 회원가입용 토큰' 생성 (변경 없음)
+    // 1. OAuth2SuccessHandler용 임시 토큰 생성
     public String createTempSignupToken(OAuth2CustomUser oAuth2User) throws JsonProcessingException {
-        // ... (로직 유지)
+        // 이 메서드는 UserNotRegisteredException을 사용하면 호출되지 않지만, 유지합니다.
         Map<String, Object> attributes = oAuth2User.getAttributes();
-        String attributesJson = objectMapper.writeValueAsString(attributes);
+
+        // Unmodifiable Map 에러 방지용 복사
+        Map<String, Object> modifiableAttributes = new HashMap<>(attributes);
+        modifiableAttributes.put("provider", oAuth2User.getRegistrationId());
+
+        String attributesJson = objectMapper.writeValueAsString(modifiableAttributes);
 
         return Jwts.builder()
-          .claim("oauth_attributes", attributesJson) // 카카오에서 받은 정보 전체를 저장
+          .claim("oauth_attributes", attributesJson)
           .issuedAt(new Date(System.currentTimeMillis()))
-          .expiration(new Date(System.currentTimeMillis() + 10 * 60 * 1000L)) // 유효시간 10분
+          .expiration(new Date(System.currentTimeMillis() + 10 * 60 * 1000L))
           .signWith(secretKey)
           .compact();
     }
 
-    // 임시 토큰에서 카카오 사용자 정보를 추출 (변경 없음)
+    // 2. SecurityConfig.failureHandler용 임시 토큰 생성
+    public String createTempSignupToken(Map<String, Object> attributes, String provider) throws JsonProcessingException {
+        // 전달받은 맵(attributes)은 수정 불가능하므로, 새 HashMap으로 복사.
+        Map<String, Object> modifiableAttributes = new HashMap<>(attributes);
+
+        // provider 정보를 수정 가능한 맵에 추가
+        modifiableAttributes.put("provider", provider);
+        String attributesJson = objectMapper.writeValueAsString(modifiableAttributes);
+
+        log.info("createTempSignupToken(Map, provider) call");
+
+        return Jwts.builder()
+          .claim("oauth_attributes", attributesJson)
+          .issuedAt(new Date(System.currentTimeMillis()))
+          .expiration(new Date(System.currentTimeMillis() + 10 * 60 * 1000L))
+          .signWith(secretKey)
+          .compact();
+    }
+
+
+    // 임시 토큰에서 카카오 사용자 정보를 추출
     public Map<String, Object> getOAuth2AttributesFromTempToken(String token) throws JsonProcessingException {
-        // ... (로직 유지)
         String attributesJson = Jwts.parser().verifyWith(secretKey).build()
           .parseSignedClaims(token).getPayload()
           .get("oauth_attributes", String.class);

--- a/schoolmate/src/main/java/com/spring/schoolmate/jwt/OAuth2SuccessHandler.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/jwt/OAuth2SuccessHandler.java
@@ -1,6 +1,5 @@
 package com.spring.schoolmate.jwt;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.spring.schoolmate.entity.Student;
 import com.spring.schoolmate.security.OAuth2CustomUser;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,11 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -27,46 +23,26 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
+
         OAuth2CustomUser oAuth2User = (OAuth2CustomUser) authentication.getPrincipal();
         Student student = oAuth2User.getStudent();
 
-        // Student 객체에 studentId가 있는지 여부로 신규/기존 회원 판별
-        boolean isNewUser = (student.getStudentId() == null);
-
-        if (isNewUser) {
-            log.info("신규 소셜 회원을 추가 정보 입력 페이지로 리다이렉트합니다.");
-            try {
-                // 1. 회원가입을 마저 진행하기 위한 임시 토큰 생성
-                String tempToken = jwtUtil.createTempSignupToken(oAuth2User);
-                log.error("!!!!!!!!!! 임시 토큰 생성 성공! TOKEN: {} !!!!!!!!!", tempToken);
-
-                // 2. 프론트에서 닉네임을 바로 쓸 수 있도록 카카오 닉네임을 추출
-                Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
-                Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-                String nickname = profile.get("nickname").toString();
-                String email = student.getEmail();
-
-                // 3. 프론트엔드의 추가 정보 입력 페이지로 리다이렉트 (임시 토큰, 닉네임 전달)
-                String redirectUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/signup")
-                        .queryParam("tempToken", tempToken)
-                        .queryParam("nickname", nickname)
-                        .queryParam("email", email)
-                        .build()
-                        .encode(StandardCharsets.UTF_8)
-                        .toUriString();
-
-                getRedirectStrategy().sendRedirect(request, response, redirectUrl);
-            } catch (JsonProcessingException e) {
-                log.error("임시 토큰 생성 중 오류가 발생했습니다.", e);
-                // TODO: 에러 페이지로 리다이렉트 하는 로직 추가
-            }
-        } else {
-            log.info("기존 회원 로그인을 완료하고 JWT를 발급합니다. Student ID: {}", student.getStudentId());
-            // 1. 최종 로그인용 JWT 생성
-            String token = jwtUtil.createJwt(student);
-            // 2. 프론트엔드의 메인 페이지 또는 토큰 처리 페이지로 리다이렉트
-            String redirectUrl = "http://localhost:3000/oauth-redirect?token=" + token;
-            getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+        // 신규 회원은 UserNotRegisteredException으로 처리되어 이 코드가 실행되지 않는다.
+        // 이 핸들러는 기존 회원 로그인 성공 시에만 호출되어야 한다.
+        if (student.getStudentId() == null) {
+            log.error("CRITICAL ERROR: OAuth2SuccessHandler가 신규 회원을 받았습니다. Security 설정을 확인하세요.");
+            response.sendRedirect("http://localhost:3000/login?error=signup_required");
+            return;
         }
+
+        log.info("기존 회원 로그인을 완료하고 JWT를 발급합니다. Student ID: {}", student.getStudentId());
+
+        // 1. 최종 로그인용 JWT 생성
+        String token = jwtUtil.createJwt(student);
+
+        // 2. 프론트엔드의 메인 페이지 또는 토큰 처리 페이지로 리다이렉트
+        String redirectUrl = "http://localhost:3000/oauth-redirect?token=" + token;
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 }

--- a/schoolmate/src/main/java/com/spring/schoolmate/security/CustomAuthorizationRequestResolver.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/security/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,64 @@
+package com.spring.schoolmate.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+  private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+  private final String frontendRedirectUri;
+
+  public CustomAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository, String frontendRedirectUri) {
+    this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+      clientRegistrationRepository, "/oauth2/authorization");
+    this.frontendRedirectUri = frontendRedirectUri;
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+    OAuth2AuthorizationRequest authorizationRequest = this.defaultResolver.resolve(request);
+    return customizeAuthorizationRequest(authorizationRequest);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+    OAuth2AuthorizationRequest authorizationRequest = this.defaultResolver.resolve(request, clientRegistrationId);
+    return customizeAuthorizationRequest(authorizationRequest, clientRegistrationId);
+  }
+
+  // resolve(request)를 위한 커스터마이징 메서드
+  private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest) {
+    if (authorizationRequest == null) {
+      return null;
+    }
+
+    String clientRegistrationId = (String) authorizationRequest.getAdditionalParameters().get("registration_id");
+
+    if (clientRegistrationId != null && "kakao".equals(clientRegistrationId)) {
+      return OAuth2AuthorizationRequest.from(authorizationRequest)
+        .redirectUri(this.frontendRedirectUri)
+        .build();
+    }
+
+    return authorizationRequest;
+  }
+
+  // resolve(request, clientRegistrationId)를 위한 커스터마이징 메서드
+  private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, String clientRegistrationId) {
+    if (authorizationRequest == null) {
+      return null;
+    }
+
+    // 파라미터로 받은 clientRegistrationId를 사용.
+    if ("kakao".equals(clientRegistrationId)) {
+      return OAuth2AuthorizationRequest.from(authorizationRequest)
+        .redirectUri(this.frontendRedirectUri)
+        .build();
+    }
+
+    return authorizationRequest;
+  }
+}

--- a/schoolmate/src/main/java/com/spring/schoolmate/service/CustomOAuth2UserService.java
+++ b/schoolmate/src/main/java/com/spring/schoolmate/service/CustomOAuth2UserService.java
@@ -1,9 +1,8 @@
 package com.spring.schoolmate.service;
 
 import com.spring.schoolmate.entity.Student;
-import com.spring.schoolmate.entity.Role;
 import com.spring.schoolmate.repository.StudentRepository;
-import com.spring.schoolmate.repository.RoleRepository; // 🚨 RoleRepository 임포트 추가
+import com.spring.schoolmate.repository.RoleRepository;
 import com.spring.schoolmate.security.OAuth2CustomUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +12,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import com.spring.schoolmate.exception.UserNotRegisteredException;
 
 import java.util.Collections;
 import java.util.Map;
@@ -24,57 +24,61 @@ import java.util.Optional;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final StudentRepository studentRepository;
-    private final RoleRepository roleRepository; // 🚨 RoleRepository 주입
+    private final RoleRepository roleRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-
-        // getNameAttributeKey 대신 userRequest에서 추출
         String userNameAttributeName = userRequest.getClientRegistration()
           .getProviderDetails()
           .getUserInfoEndpoint()
           .getUserNameAttributeName();
-
         Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 신규 회원일 경우 여기서 예외를 던진다.
         Student student = findOrCreateStudent(registrationId, attributes);
 
-        // OAuth2CustomUser 생성 시 5가지 인수를 모두 전달
+        // 기존 회원만 아래 코드가 실행된다.
         return new OAuth2CustomUser(
           Collections.singleton(new SimpleGrantedAuthority("ROLE_STUDENT")),
           attributes,
           userNameAttributeName,
-          student,
+          student, // 이 시점의 student는 DB에 존재하는 기존 회원.
           registrationId
         );
     }
 
     private Student findOrCreateStudent(String registrationId, Map<String, Object> attributes) {
+        // null 체크 추가: kakao_account나 email이 null인 경우를 방지.
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        String email = (String) kakaoAccount.get("email");
+        if (kakaoAccount == null) {
+            log.error("카카오 속성(attributes)에 'kakao_account' 필드가 누락되었습니다: {}", attributes);
+            throw new OAuth2AuthenticationException("카카오 계정 세부 정보를 검색할 수 없습니다.");
+        }
 
-        // 1. 이메일로 DB에서 사용자를 찾아봅니다.
+        String email = (String) kakaoAccount.get("email");
+        if (email == null) {
+            log.error("카카오 계정(kakao account)에 'email' 필드가 누락되었습니다: {}", kakaoAccount);
+            throw new OAuth2AuthenticationException("소셜 로그인을 위해서는 이메일이 필수입니다.");
+        }
+
+
+        // 1. 이메일로 DB에서 사용자를 찾아본다.
         Optional<Student> existingStudentOptional = studentRepository.findByEmail(email);
 
         if (existingStudentOptional.isPresent()) {
-            // 2. 사용자가 이미 존재하면, 그 사용자 정보를 반환합니다.
+            // 2. 사용자가 이미 존재하면, 그 사용자 정보를 반환.
             log.info("기존 소셜 회원 발견: {}", email);
             return existingStudentOptional.get();
         } else {
-            // 3. 사용자가 존재하지 않으면, '신규 회원'으로 판단하고
-            //    추가 정보 입력을 위한 임시 Student 객체를 생성하여 반환합니다.
-            //    이 객체는 아직 DB에 저장되지 않았으므로 studentId가 null입니다.
-            log.info("신규 소셜 회원! 추가 정보 입력이 필요합니다: {}", email);
-            Role studentRole = roleRepository.findByRoleName(Role.RoleType.STUDENT)
-                    .orElseThrow(() -> new RuntimeException("STUDENT Role not found"));
-
-            return Student.builder()
-                    .email(email)
-                    .role(studentRole)
-                    .provider(registrationId) // "kakao"
-                    .build();
+            log.info("신규 소셜 회원 감지! UserNotRegisteredException 발생: {}", email);
+            throw new UserNotRegisteredException(
+              "사용자가 등록되지 않았습니다. 회원가입을 진행합니다.", // 메시지
+              attributes,
+              registrationId
+            );
         }
     }
 }


### PR DESCRIPTION
jira : KAN-56

# Todo
- [x] Custom Authorization Request Resolver 빈 등록 (redirect-uri 처리)
- [x] OAuth2 로그인 엔드포인트 설정
- [x] UserNotRegisteredException을 처리하여 /signup으로 리다이렉트하는 핸들러 추가 

# etc
- 기존: 소셜 로그인 진행 시 DB에 회원정보가 없다면 회원가입을 진행하려 했지만 계속해서 localhost:9000/login으로 남아있게 됨.
- 수정: 프론트 코드 OAuthRedirectHandler에서 신규 회원: 임시 토큰(tempToken)이 있는지 최우선으로 확인 + redirectPath 변수를 정확하게 정의 + navigate 대신 window.location.replace를 사용하여 확실하게 이동 처리
- 결과: localhost:3000/signup으로 redirect 성공 -> 이메일과 닉네임이 정확하게 input에 들어간 것을 확인